### PR TITLE
Provide TARGET and TARGET_CFLAGS for 64-bit RISC-V and 32-bit Arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ ifeq ($(shell arch), ppc64)
   TARGET=PPC64
   TARGET_CFLAGS=-m64
 endif
+ifeq ($(shell arch), ppc64le)
+  TARGET=PPC64
+  TARGET_CFLAGS=-m64
+endif
 ifeq ($(shell arch), ia64)
   TARGET=IA64
   TARGET_CFLAGS=
@@ -20,6 +24,10 @@ ifeq ($(shell arch), s390x)
 endif
 ifeq ($(shell arch), s390)
   TARGET=S390
+  TARGET_CFLAGS=
+endif
+ifeq ($(shell arch), aarch64)
+  TARGET=ARM64
   TARGET_CFLAGS=
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ ifeq ($(patsubst arm%,arm,$(shell arch)), arm)
   TARGET=ARM
   TARGET_CFLAGS=
 endif
+ifeq ($(shell arch), riscv64)
+  TARGET=RISCV64
+  TARGET_CFLAGS=
+endif
 
 INCDIR=/usr/include/crash
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ ifeq ($(shell arch), aarch64)
   TARGET=ARM64
   TARGET_CFLAGS=
 endif
+ifeq ($(patsubst arm%,arm,$(shell arch)), arm)
+  TARGET=ARM
+  TARGET_CFLAGS=
+endif
 
 INCDIR=/usr/include/crash
 


### PR DESCRIPTION
Fix build for riscv64 and arm* target architectures.